### PR TITLE
add optional headers to file backend

### DIFF
--- a/file/options.go
+++ b/file/options.go
@@ -1,0 +1,26 @@
+/*
+ * This file is part of easyKV.
+ * © 2016 The easyKV Authors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+package file
+
+// Options contains all (possibly optional) values that are needed to fetch
+// JSON or YAML files (either locally or remotely).
+type Options struct {
+	Headers map[string]string
+}
+
+// Option configures the file client.
+type Option func(*Options)
+
+// WithHeaders sets the headers for the HTTP request made when fetching
+// remote files.
+func WithHeaders(headers map[string]string) Option {
+	return func(o *Options) {
+		o.Headers = headers
+	}
+}


### PR DESCRIPTION
First step before https://github.com/HeavyHorst/remco/issues/34.

I didn't want to change the logic of GetValues, so I opted for a custom transport that will attach any optional headers for us. Alternatively, I was thinking maybe we could split out the remote file functionality out of `file` into its own `http` backend? It doesn't feel necessary right now, but I feel if more options are ever added, it might be.

Advice on how I might write some tests for this would be appreciated! I looked through the other backends, and noticed their options aren't really tested either though, so idk if you're cool with just this.