### PR TITLE
 Add an option for etcd to choose linearizable reads

### DIFF
--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -33,11 +33,11 @@ func New(machines []string, opts ...Option) (easykv.ReadWatcher, error) {
 	}
 
 	if options.Version == 3 {
-		return etcdv3.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password)
+		return etcdv3.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password, options.Serializable)
 	}
 
 	if options.Version == 2 {
-		return etcdv2.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password)
+		return etcdv2.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password, options.Serializable)
 	}
 
 	return nil, ErrUnknownAPILevel

--- a/etcd/etcdv2/client.go
+++ b/etcd/etcdv2/client.go
@@ -32,7 +32,7 @@ import (
 
 // Client is a wrapper around the etcd client
 type Client struct {
-	client client.KeysAPI
+	client       client.KeysAPI
 	serializable bool
 }
 

--- a/etcd/etcdv2/client.go
+++ b/etcd/etcdv2/client.go
@@ -33,10 +33,11 @@ import (
 // Client is a wrapper around the etcd client
 type Client struct {
 	client client.KeysAPI
+	serializable bool
 }
 
 // NewEtcdClient returns an *etcd.Client with a connection to named machines.
-func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string, serializable bool) (*Client, error) {
 	var c client.Client
 	var kapi client.KeysAPI
 	var err error
@@ -66,7 +67,7 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 	if caCert != "" {
 		certBytes, err := ioutil.ReadFile(caCert)
 		if err != nil {
-			return &Client{kapi}, err
+			return &Client{kapi, serializable}, err
 		}
 
 		caCertPool := x509.NewCertPool()
@@ -80,7 +81,7 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 	if cert != "" && key != "" {
 		tlsCert, err := tls.LoadX509KeyPair(cert, key)
 		if err != nil {
-			return &Client{kapi}, err
+			return &Client{kapi, serializable}, err
 		}
 		tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	}
@@ -90,11 +91,11 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 
 	c, err = client.New(cfg)
 	if err != nil {
-		return &Client{kapi}, err
+		return &Client{kapi, serializable}, err
 	}
 
 	kapi = client.NewKeysAPI(c)
-	return &Client{kapi}, nil
+	return &Client{kapi, serializable}, nil
 }
 
 // Close is only meant to fulfill the easykv.ReadWatcher interface.
@@ -109,7 +110,7 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 		resp, err := c.client.Get(context.Background(), key, &client.GetOptions{
 			Recursive: true,
 			Sort:      true,
-			Quorum:    true,
+			Quorum:    !c.serializable,
 		})
 		if err != nil {
 			return vars, err

--- a/etcd/etcdv2/client_test.go
+++ b/etcd/etcdv2/client_test.go
@@ -27,7 +27,7 @@ type FilterSuite struct{}
 var _ = Suite(&FilterSuite{})
 
 func (s *FilterSuite) TestGetValues(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func (s *FilterSuite) TestGetValues(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefix(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func (s *FilterSuite) TestWatchPrefix(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefixCancel(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/etcd/etcdv3/client.go
+++ b/etcd/etcdv3/client.go
@@ -21,7 +21,7 @@ import (
 
 // Client is a wrapper around the etcd client
 type Client struct {
-	client *clientv3.Client
+	client       *clientv3.Client
 	serializable bool
 }
 

--- a/etcd/etcdv3/client.go
+++ b/etcd/etcdv3/client.go
@@ -22,10 +22,11 @@ import (
 // Client is a wrapper around the etcd client
 type Client struct {
 	client *clientv3.Client
+	serializable bool
 }
 
 // NewEtcdClient returns an *etcdv3.Client with a connection to named machines.
-func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string, serializable bool) (*Client, error) {
 	var cli *clientv3.Client
 	cfg := clientv3.Config{
 		Endpoints:   machines,
@@ -52,16 +53,16 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 	if tls {
 		clientConf, err := tlsInfo.ClientConfig()
 		if err != nil {
-			return &Client{cli}, err
+			return &Client{cli, serializable}, err
 		}
 		cfg.TLS = clientConf
 	}
 
 	cli, err := clientv3.New(cfg)
 	if err != nil {
-		return &Client{cli}, err
+		return &Client{cli, serializable}, err
 	}
-	return &Client{cli}, nil
+	return &Client{cli, serializable}, nil
 }
 
 // Close closes the etcdv3 client connection.
@@ -77,7 +78,11 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 	vars := make(map[string]string)
 	for _, key := range keys {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(3)*time.Second)
-		resp, err := c.client.Get(ctx, key, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
+		opts := []clientv3.OpOption{clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend)}
+		if c.serializable {
+			opts = append(opts, clientv3.WithSerializable())
+		}
+		resp, err := c.client.Get(ctx, key, opts...)
 		cancel()
 		if err != nil {
 			return vars, err

--- a/etcd/etcdv3/client_test.go
+++ b/etcd/etcdv3/client_test.go
@@ -27,7 +27,7 @@ type FilterSuite struct{}
 var _ = Suite(&FilterSuite{})
 
 func (s *FilterSuite) TestGetValues(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func (s *FilterSuite) TestGetValues(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefix(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func (s *FilterSuite) TestWatchPrefix(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefixCancel(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/etcd/options.go
+++ b/etcd/options.go
@@ -12,6 +12,7 @@ package etcd
 type Options struct {
 	Nodes   []string
 	Version int
+	Serializable bool
 	TLS     TLSOptions
 	Auth    BasicAuthOptions
 }

--- a/etcd/options.go
+++ b/etcd/options.go
@@ -10,11 +10,11 @@ package etcd
 
 // Options contains all values that are needed to connect to etcd.
 type Options struct {
-	Nodes   []string
-	Version int
+	Nodes        []string
+	Version      int
 	Serializable bool
-	TLS     TLSOptions
-	Auth    BasicAuthOptions
+	TLS          TLSOptions
+	Auth         BasicAuthOptions
 }
 
 // TLSOptions contains all certificates and keys.

--- a/etcd/options.go
+++ b/etcd/options.go
@@ -53,3 +53,9 @@ func WithVersion(v int) Option {
 		o.Version = v
 	}
 }
+
+func WithSerializableReads(b bool) Option {
+	return func(o *Options) {
+		o.Serializable = b
+	}
+}


### PR DESCRIPTION
easyKV uses [linearizable reads](https://etcd.io/docs/v3.3/learning/api_guarantees/#linearizability) with both etcd v2 and etcd v3. This comes with a delay cost, so this gives a choice to use linearizable reads instead.