### PR TITLE
Add an etcd backend options to configure request timeout

### DIFF
--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -10,6 +10,7 @@ package etcd
 
 import (
 	"errors"
+	"time"
 
 	"github.com/HeavyHorst/easykv"
 	"github.com/HeavyHorst/easykv/etcd/etcdv2"
@@ -32,12 +33,19 @@ func New(machines []string, opts ...Option) (easykv.ReadWatcher, error) {
 		ba = true
 	}
 
+	var requestTimeout time.Duration
+	if options.RequestTimeout == 0 {
+		requestTimeout = time.Duration(3) * time.Second
+	} else {
+		requestTimeout = time.Duration(options.RequestTimeout) * time.Second
+	}
+
 	if options.Version == 3 {
-		return etcdv3.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password)
+		return etcdv3.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password, requestTimeout)
 	}
 
 	if options.Version == 2 {
-		return etcdv2.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password)
+		return etcdv2.NewEtcdClient(options.Nodes, options.TLS.ClientCert, options.TLS.ClientKey, options.TLS.ClientCaKeys, ba, options.Auth.Username, options.Auth.Password, requestTimeout)
 	}
 
 	return nil, ErrUnknownAPILevel

--- a/etcd/etcdv2/client.go
+++ b/etcd/etcdv2/client.go
@@ -36,7 +36,7 @@ type Client struct {
 }
 
 // NewEtcdClient returns an *etcd.Client with a connection to named machines.
-func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string, requestTimeout time.Duration) (*Client, error) {
 	var c client.Client
 	var kapi client.KeysAPI
 	var err error
@@ -55,7 +55,7 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 
 	cfg := client.Config{
 		Endpoints:               machines,
-		HeaderTimeoutPerRequest: time.Duration(3) * time.Second,
+		HeaderTimeoutPerRequest: requestTimeout,
 	}
 
 	if basicAuth {

--- a/etcd/etcdv2/client_test.go
+++ b/etcd/etcdv2/client_test.go
@@ -27,7 +27,7 @@ type FilterSuite struct{}
 var _ = Suite(&FilterSuite{})
 
 func (s *FilterSuite) TestGetValues(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func (s *FilterSuite) TestGetValues(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefix(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func (s *FilterSuite) TestWatchPrefix(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefixCancel(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
 	if err != nil {
 		t.Error(err)
 	}

--- a/etcd/etcdv2/client_test.go
+++ b/etcd/etcdv2/client_test.go
@@ -27,7 +27,7 @@ type FilterSuite struct{}
 var _ = Suite(&FilterSuite{})
 
 func (s *FilterSuite) TestGetValues(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3)*time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func (s *FilterSuite) TestGetValues(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefix(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3)*time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func (s *FilterSuite) TestWatchPrefix(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefixCancel(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3)*time.Second)
 	if err != nil {
 		t.Error(err)
 	}

--- a/etcd/etcdv3/client.go
+++ b/etcd/etcdv3/client.go
@@ -22,10 +22,11 @@ import (
 // Client is a wrapper around the etcd client
 type Client struct {
 	client *clientv3.Client
+	requestTimeout time.Duration
 }
 
 // NewEtcdClient returns an *etcdv3.Client with a connection to named machines.
-func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string, requestTimeout time.Duration) (*Client, error) {
 	var cli *clientv3.Client
 	cfg := clientv3.Config{
 		Endpoints:   machines,
@@ -52,16 +53,16 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 	if tls {
 		clientConf, err := tlsInfo.ClientConfig()
 		if err != nil {
-			return &Client{cli}, err
+			return &Client{cli, requestTimeout}, err
 		}
 		cfg.TLS = clientConf
 	}
 
 	cli, err := clientv3.New(cfg)
 	if err != nil {
-		return &Client{cli}, err
+		return &Client{cli, requestTimeout}, err
 	}
-	return &Client{cli}, nil
+	return &Client{cli, requestTimeout}, nil
 }
 
 // Close closes the etcdv3 client connection.
@@ -76,7 +77,7 @@ func (c *Client) Close() {
 func (c *Client) GetValues(keys []string) (map[string]string, error) {
 	vars := make(map[string]string)
 	for _, key := range keys {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(3)*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), c.requestTimeout)
 		resp, err := c.client.Get(ctx, key, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
 		cancel()
 		if err != nil {

--- a/etcd/etcdv3/client.go
+++ b/etcd/etcdv3/client.go
@@ -21,7 +21,7 @@ import (
 
 // Client is a wrapper around the etcd client
 type Client struct {
-	client *clientv3.Client
+	client         *clientv3.Client
 	requestTimeout time.Duration
 }
 

--- a/etcd/etcdv3/client_test.go
+++ b/etcd/etcdv3/client_test.go
@@ -27,7 +27,7 @@ type FilterSuite struct{}
 var _ = Suite(&FilterSuite{})
 
 func (s *FilterSuite) TestGetValues(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func (s *FilterSuite) TestGetValues(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefix(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func (s *FilterSuite) TestWatchPrefix(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefixCancel(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "")
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
 	if err != nil {
 		t.Error(err)
 	}

--- a/etcd/etcdv3/client_test.go
+++ b/etcd/etcdv3/client_test.go
@@ -27,7 +27,7 @@ type FilterSuite struct{}
 var _ = Suite(&FilterSuite{})
 
 func (s *FilterSuite) TestGetValues(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3)*time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func (s *FilterSuite) TestGetValues(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefix(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3)*time.Second)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func (s *FilterSuite) TestWatchPrefix(t *C) {
 }
 
 func (s *FilterSuite) TestWatchPrefixCancel(t *C) {
-	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3) * time.Second)
+	c, err := NewEtcdClient([]string{"http://localhost:2379"}, "", "", "", false, "", "", time.Duration(3)*time.Second)
 	if err != nil {
 		t.Error(err)
 	}

--- a/etcd/options.go
+++ b/etcd/options.go
@@ -10,11 +10,11 @@ package etcd
 
 // Options contains all values that are needed to connect to etcd.
 type Options struct {
-	Nodes   []string
-	Version int
+	Nodes          []string
+	Version        int
 	RequestTimeout int
-	TLS     TLSOptions
-	Auth    BasicAuthOptions
+	TLS            TLSOptions
+	Auth           BasicAuthOptions
 }
 
 // TLSOptions contains all certificates and keys.

--- a/etcd/options.go
+++ b/etcd/options.go
@@ -12,6 +12,7 @@ package etcd
 type Options struct {
 	Nodes   []string
 	Version int
+	RequestTimeout int
 	TLS     TLSOptions
 	Auth    BasicAuthOptions
 }
@@ -50,5 +51,11 @@ func WithBasicAuth(b BasicAuthOptions) Option {
 func WithVersion(v int) Option {
 	return func(o *Options) {
 		o.Version = v
+	}
+}
+
+func WithRequestTimeout(t int) Option {
+	return func(o *Options) {
+		o.RequestTimeout = t
 	}
 }


### PR DESCRIPTION
This adds an option to configure the etcd request timeout. By default, it will be three seconds, like before this PR.